### PR TITLE
adding # to shebang in types-loops-tools/structure.py script

### DIFF
--- a/intro-python/types-loops-tools/structure.py
+++ b/intro-python/types-loops-tools/structure.py
@@ -1,4 +1,4 @@
-!/usr/bin/env python
+#!/usr/bin/env python
 """Module docstring.
 
 Copyright (c) 2018-2021 Cisco and/or its affiliates.


### PR DESCRIPTION
found missing # in shebang inside script types-loops-tools/structure.py 